### PR TITLE
fix: remove refs_heads_ prefix from branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: crowdin action
-      uses: ardeois/better-crowdin-action@v1.0
+      uses: ardeois/better-crowdin-action@v1.1
       with:
         action: 'upload sources'
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,7 @@ init_options() {
   fi
 
   if [[ -n "$INPUT_BRANCH" ]]; then
+    INPUT_BRANCH=$(echo $INPUT_BRANCH | sed "s/^refs\/heads\///")
     OPTIONS="${OPTIONS} --branch=${INPUT_BRANCH}"
   fi
 


### PR DESCRIPTION
If provided branch name starts with `refs_heads_` (which is the default behaviour from github action ref), we remove it.